### PR TITLE
feat: HL7 v2 spec conformance - trim CR, validate segment ID, MSH spe…

### DIFF
--- a/src/__tests__/field-operations.test.ts
+++ b/src/__tests__/field-operations.test.ts
@@ -7,7 +7,7 @@ describe('extractFieldValue', () => {
       expect(extractFieldValue('PID|1|12345|SMITH^JOHN', 0)).toBe('PID')
     })
 
-    it('deve extrair campo existente pelo índice', () => {
+    it('deve extrair campos pelo índice', () => {
       const segment = 'PID|1|12345|SMITH^JOHN|19800101|M'
 
       expect(extractFieldValue(segment, 1)).toBe('1')
@@ -17,35 +17,36 @@ describe('extractFieldValue', () => {
       expect(extractFieldValue(segment, 5)).toBe('M')
     })
 
-    it('deve retornar string vazia para campo vazio intermediário', () => {
-      const segment = 'PID|1||SMITH^JOHN'
-
-      expect(extractFieldValue(segment, 2)).toBe('')
+    it('deve retornar string vazia para campo existente mas vazio', () => {
+      expect(extractFieldValue('PID|1||SMITH^JOHN', 2)).toBe('')
     })
 
     it('deve retornar string vazia para campo vazio no final', () => {
-      const segment = 'PID|1|12345|'
-
-      expect(extractFieldValue(segment, 3)).toBe('')
+      expect(extractFieldValue('PID|1|12345|', 3)).toBe('')
     })
 
     it('deve retornar null para índice além do range', () => {
-      const segment = 'PID|1|12345'
-
-      expect(extractFieldValue(segment, 5)).toBe(null)
-      expect(extractFieldValue(segment, 10)).toBe(null)
+      expect(extractFieldValue('PID|1|12345', 5)).toBe(null)
+      expect(extractFieldValue('PID|1|12345', 10)).toBe(null)
     })
 
-    it('deve extrair campo com subcomponentes (^) preservando o valor', () => {
-      const segment = 'PV1|1|I|2000^2012^01'
-
-      expect(extractFieldValue(segment, 3)).toBe('2000^2012^01')
+    it('deve preservar subcomponentes (^) sem decodificar', () => {
+      expect(extractFieldValue('PV1|1|I|2000^2012^01', 3)).toBe('2000^2012^01')
     })
 
-    it('deve extrair campo com repetições (~) preservando o valor', () => {
-      const segment = 'MSH|^~\\&|APP|FAC'
+    it('deve preservar encoding chars do MSH-1', () => {
+      expect(extractFieldValue('MSH|^~\\&|APP|FAC', 1)).toBe('^~\\&')
+    })
 
-      expect(extractFieldValue(segment, 1)).toBe('^~\\&')
+    it('deve remover \\r do final antes de extrair', () => {
+      const result = extractFieldValue('PID|1|12345|SMITH^JOHN\r', 3)
+
+      expect(result).toBe('SMITH^JOHN')
+      expect(result).not.toContain('\r')
+    })
+
+    it('deve remover espaços nas extremidades antes de extrair', () => {
+      expect(extractFieldValue('  PID|1|12345  ', 1)).toBe('1')
     })
   })
 
@@ -60,6 +61,15 @@ describe('extractFieldValue', () => {
 
     it('deve retornar null para segmento com tipo inválido', () => {
       expect(extractFieldValue('AB|campo', 1)).toBe(null)
+      expect(extractFieldValue('pid|campo', 1)).toBe(null)
+    })
+
+    it('deve retornar null para índice negativo', () => {
+      expect(extractFieldValue('PID|1|12345', -1)).toBe(null)
+    })
+
+    it('deve retornar null para índice não inteiro', () => {
+      expect(extractFieldValue('PID|1|12345', 1.5)).toBe(null)
     })
   })
 })
@@ -67,43 +77,44 @@ describe('extractFieldValue', () => {
 describe('setFieldValue', () => {
   describe('modificação de campos', () => {
     it('deve modificar campo existente pelo índice', () => {
-      const result = setFieldValue('PID|1|12345|SMITH^JOHN', 2, '67890')
-
-      expect(result).toBe('PID|1|67890|SMITH^JOHN')
+      expect(setFieldValue('PID|1|12345|SMITH^JOHN', 2, '67890')).toBe(
+        'PID|1|67890|SMITH^JOHN'
+      )
     })
 
     it('deve modificar o tipo do segmento (índice 0)', () => {
-      const result = setFieldValue('PID|1|12345', 0, 'NK1')
-
-      expect(result).toBe('NK1|1|12345')
+      expect(setFieldValue('PID|1|12345', 0, 'NK1')).toBe('NK1|1|12345')
     })
 
     it('deve substituir campo vazio intermediário', () => {
-      const result = setFieldValue('PID|1||SMITH^JOHN', 2, '12345')
-
-      expect(result).toBe('PID|1|12345|SMITH^JOHN')
-    })
-
-    it('deve criar campos vazios intermediários se o índice for além do range', () => {
-      const result = setFieldValue('PID|1|12345', 5, 'M')
-
-      expect(result).toBe('PID|1|12345|||M')
-    })
-
-    it('deve definir valor em segmento com apenas o tipo', () => {
-      const result = setFieldValue('MSH', 1, '^~\\&')
-
-      expect(result).toBe('MSH|^~\\&')
-    })
-
-    it('deve preservar campos com subcomponentes não modificados', () => {
-      const result = setFieldValue(
-        'PID|1|12345|SMITH^JOHN|19800101',
-        2,
-        '99999'
+      expect(setFieldValue('PID|1||SMITH^JOHN', 2, '12345')).toBe(
+        'PID|1|12345|SMITH^JOHN'
       )
+    })
 
-      expect(result).toBe('PID|1|99999|SMITH^JOHN|19800101')
+    it('deve criar campos vazios intermediários se necessário', () => {
+      expect(setFieldValue('PID|1|12345', 5, 'M')).toBe('PID|1|12345|||M')
+    })
+
+    it('deve definir valor em segmento apenas com tipo', () => {
+      expect(setFieldValue('MSH', 1, '^~\\&')).toBe('MSH|^~\\&')
+    })
+
+    it('deve preservar campos não modificados', () => {
+      expect(setFieldValue('PID|1|12345|SMITH^JOHN|19800101', 2, '99999')).toBe(
+        'PID|1|99999|SMITH^JOHN|19800101'
+      )
+    })
+
+    it('deve remover \\r do final antes de modificar', () => {
+      const result = setFieldValue('PID|1|12345|SMITH^JOHN\r', 2, '99999')
+
+      expect(result).toBe('PID|1|99999|SMITH^JOHN')
+      expect(result).not.toContain('\r')
+    })
+
+    it('deve remover espaços nas extremidades antes de modificar', () => {
+      expect(setFieldValue('  PID|1|12345  ', 1, '99')).toBe('PID|99|12345')
     })
   })
 
@@ -120,15 +131,24 @@ describe('setFieldValue', () => {
       ).toThrow('Segmento HL7 inválido')
     })
 
-    it('deve lançar erro para índice negativo', () => {
-      expect(() => setFieldValue('PID|1', -1, 'value')).toThrow(
-        'Índice do campo deve ser maior ou igual a 0'
-      )
-    })
-
     it('deve lançar erro para segmento com tipo inválido', () => {
       expect(() => setFieldValue('AB|campo', 1, 'value')).toThrow(
         'Segmento HL7 inválido'
+      )
+      expect(() => setFieldValue('pid|campo', 1, 'value')).toThrow(
+        'Segmento HL7 inválido'
+      )
+    })
+
+    it('deve lançar erro para índice negativo', () => {
+      expect(() => setFieldValue('PID|1', -1, 'value')).toThrow(
+        'Índice do campo deve ser um inteiro maior ou igual a 0'
+      )
+    })
+
+    it('deve lançar erro para índice não inteiro', () => {
+      expect(() => setFieldValue('PID|1', 1.5, 'value')).toThrow(
+        'Índice do campo deve ser um inteiro maior ou igual a 0'
       )
     })
   })

--- a/src/__tests__/field-operations.test.ts
+++ b/src/__tests__/field-operations.test.ts
@@ -34,8 +34,24 @@ describe('extractFieldValue', () => {
       expect(extractFieldValue('PV1|1|I|2000^2012^01', 3)).toBe('2000^2012^01')
     })
 
-    it('deve preservar encoding chars do MSH-1', () => {
-      expect(extractFieldValue('MSH|^~\\&|APP|FAC', 1)).toBe('^~\\&')
+    it('deve retornar o field separator para MSH índice 1 (MSH-1)', () => {
+      expect(extractFieldValue('MSH|^~\\&|APP|FAC', 1)).toBe('|')
+    })
+
+    it('deve retornar encoding chars para MSH índice 2 (MSH-2)', () => {
+      expect(extractFieldValue('MSH|^~\\&|APP|FAC', 2)).toBe('^~\\&')
+    })
+
+    it('deve retornar APP para MSH índice 3 (MSH-3)', () => {
+      expect(extractFieldValue('MSH|^~\\&|APP|FAC', 3)).toBe('APP')
+    })
+
+    it('deve retornar FAC para MSH índice 4 (MSH-4)', () => {
+      expect(extractFieldValue('MSH|^~\\&|APP|FAC', 4)).toBe('FAC')
+    })
+
+    it('deve retornar null para índice além do range em MSH', () => {
+      expect(extractFieldValue('MSH|^~\\&|APP|FAC', 10)).toBe(null)
     })
 
     it('deve remover \\r do final antes de extrair', () => {
@@ -96,8 +112,32 @@ describe('setFieldValue', () => {
       expect(setFieldValue('PID|1|12345', 5, 'M')).toBe('PID|1|12345|||M')
     })
 
-    it('deve definir valor em segmento apenas com tipo', () => {
-      expect(setFieldValue('MSH', 1, '^~\\&')).toBe('MSH|^~\\&')
+    it('deve definir encoding chars em MSH sem campos (índice 2 = MSH-2)', () => {
+      expect(setFieldValue('MSH', 2, '^~\\&')).toBe('MSH|^~\\&')
+    })
+
+    it('deve modificar MSH-2 (encoding chars) via índice 2', () => {
+      expect(setFieldValue('MSH|^~\\&|APP|FAC', 2, '^~\\&#')).toBe(
+        'MSH|^~\\&#|APP|FAC'
+      )
+    })
+
+    it('deve modificar MSH-3 (sending app) via índice 3', () => {
+      expect(setFieldValue('MSH|^~\\&|APP|FAC', 3, 'NEWAPP')).toBe(
+        'MSH|^~\\&|NEWAPP|FAC'
+      )
+    })
+
+    it('deve modificar MSH-4 (sending facility) via índice 4', () => {
+      expect(setFieldValue('MSH|^~\\&|APP|FAC', 4, 'NEWFAC')).toBe(
+        'MSH|^~\\&|APP|NEWFAC'
+      )
+    })
+
+    it('deve criar campos vazios intermediários em MSH se necessário', () => {
+      expect(setFieldValue('MSH|^~\\&|APP', 6, 'DEST')).toBe(
+        'MSH|^~\\&|APP|||DEST'
+      )
     })
 
     it('deve preservar campos não modificados', () => {

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -2,40 +2,35 @@ import { describe, expect, it } from 'vitest'
 import { createHL7Segment, parseHL7Segment } from '../functions/parser'
 
 describe('parseHL7Segment', () => {
-  describe('casos válidos', () => {
-    it('deve parsear segmento MSH simples', () => {
-      const result = parseHL7Segment('MSH|^~\\&|SENDING_APP|SENDING_FACILITY')
+  describe('casos válidos — segmentos comuns', () => {
+    it('deve parsear segmento PID simples', () => {
+      const result = parseHL7Segment('PID|1|12345|SMITH^JOHN|19800101|M')
 
-      expect(result.segmentType).toBe('MSH')
-      expect(result.field1).toBe('^~\\&')
-      expect(result.field2).toBe('SENDING_APP')
-      expect(result.field3).toBe('SENDING_FACILITY')
+      expect(result.segmentType).toBe('PID')
+      expect(result.field1).toBe('1')
+      expect(result.field2).toBe('12345')
+      expect(result.field3).toBe('SMITH^JOHN')
+      expect(result.field4).toBe('19800101')
+      expect(result.field5).toBe('M')
     })
 
-    it('deve parsear segmento MSH completo com 12 campos', () => {
-      const segment =
-        'MSH|^~\\&|SENDING_APP|SENDING_FAC|RECEIVING_APP|RECEIVING_FAC|20231201120000||ADT^A01|MSG00001|P|2.5'
-      const result = parseHL7Segment(segment)
-
-      expect(result.segmentType).toBe('MSH')
-      expect(result.field1).toBe('^~\\&')
-      expect(result.field8).toBe('ADT^A01')
-      expect(result.field9).toBe('MSG00001')
-      expect(result.field11).toBe('2.5')
-    })
-
-    it('deve parsear segmento PID com subcomponentes (^)', () => {
+    it('deve parsear segmento com subcomponentes (^) como string preservada', () => {
       const result = parseHL7Segment('PID|1|12345|SMITH^JOHN^A|19800101|M')
 
       expect(result.segmentType).toBe('PID')
       expect(result.field3).toBe('SMITH^JOHN^A')
-      expect(result.field4).toBe('19800101')
     })
 
-    it('deve parsear segmento com campos vazios intermediários', () => {
+    it('deve parsear segmento com repetições (~) como string preservada', () => {
+      const result = parseHL7Segment('PV1|1|I|2000^2012^01~3000^3001^02')
+
+      expect(result.segmentType).toBe('PV1')
+      expect(result.field3).toBe('2000^2012^01~3000^3001^02')
+    })
+
+    it('deve parsear campos vazios intermediários como string vazia', () => {
       const result = parseHL7Segment('PID|1||SMITH^JOHN||19800101')
 
-      expect(result.segmentType).toBe('PID')
       expect(result.field1).toBe('1')
       expect(result.field2).toBe('')
       expect(result.field3).toBe('SMITH^JOHN')
@@ -43,25 +38,69 @@ describe('parseHL7Segment', () => {
       expect(result.field5).toBe('19800101')
     })
 
-    it('deve parsear segmento PV1 com repetições (~)', () => {
-      const result = parseHL7Segment('PV1|1|I|2000^2012^01~3000^3001^02')
-
-      expect(result.segmentType).toBe('PV1')
-      expect(result.field3).toBe('2000^2012^01~3000^3001^02')
-    })
-
-    it('deve parsear segmento com apenas o tipo e um campo', () => {
-      const result = parseHL7Segment('EVN|A01')
+    it('deve parsear segmento apenas com o tipo (sem pipe)', () => {
+      const result = parseHL7Segment('EVN')
 
       expect(result.segmentType).toBe('EVN')
-      expect(result.field1).toBe('A01')
+      expect(result.field1).toBeUndefined()
     })
 
-    it('deve retornar objeto tipado com segmentType', () => {
-      const result = parseHL7Segment('OBR|1|ORDER123')
+    it('deve remover \\r do final antes de parsear (terminador HL7)', () => {
+      const result = parseHL7Segment('PID|1|12345|SMITH^JOHN\r')
 
-      expect(typeof result.segmentType).toBe('string')
-      expect(result.segmentType).toBe('OBR')
+      expect(result.segmentType).toBe('PID')
+      expect(result.field3).toBe('SMITH^JOHN')
+      expect(result.field3).not.toContain('\r')
+    })
+
+    it('deve remover espaços nas extremidades antes de parsear', () => {
+      const result = parseHL7Segment('  PID|1|12345  ')
+
+      expect(result.segmentType).toBe('PID')
+      expect(result.field1).toBe('1')
+    })
+
+    it('deve aceitar Z-segment (extensão local)', () => {
+      const result = parseHL7Segment('ZPD|campo1|campo2')
+
+      expect(result.segmentType).toBe('ZPD')
+      expect(result.field1).toBe('campo1')
+    })
+  })
+
+  describe('MSH — tratamento especial (HL7 v2 §2.14.9)', () => {
+    it('deve parsear MSH com field1 = field separator e field2 = encoding chars', () => {
+      const result = parseHL7Segment(
+        'MSH|^~\\&|SENDING_APP|SENDING_FAC|RECV_APP|RECV_FAC|20231201||ADT^A01|MSG001|P|2.5'
+      )
+
+      expect(result.segmentType).toBe('MSH')
+      // MSH-1: o próprio separador de campo
+      expect(result.field1).toBe('|')
+      // MSH-2: encoding characters
+      expect(result.field2).toBe('^~\\&')
+      // MSH-3 em diante
+      expect(result.field3).toBe('SENDING_APP')
+      expect(result.field4).toBe('SENDING_FAC')
+      expect(result.field9).toBe('ADT^A01')
+      expect(result.field12).toBe('2.5')
+    })
+
+    it('deve parsear MSH com \\r no final', () => {
+      const result = parseHL7Segment('MSH|^~\\&|APP|FAC\r')
+
+      expect(result.segmentType).toBe('MSH')
+      expect(result.field1).toBe('|')
+      expect(result.field2).toBe('^~\\&')
+      expect(result.field4).toBe('FAC')
+    })
+
+    it('deve parsear MSH com encoding chars de 5 posições (v2.8+)', () => {
+      const result = parseHL7Segment('MSH|^~\\&#|APP|FAC')
+
+      expect(result.field1).toBe('|')
+      expect(result.field2).toBe('^~\\&#')
+      expect(result.field3).toBe('APP')
     })
   })
 
@@ -84,7 +123,23 @@ describe('parseHL7Segment', () => {
       )
     })
 
-    it('deve lançar erro para número', () => {
+    it('deve lançar erro para segment ID em minúsculas', () => {
+      expect(() => parseHL7Segment('pid|1|2')).toThrow('Segment ID inválido')
+    })
+
+    it('deve lançar erro para segment ID com 2 chars', () => {
+      expect(() => parseHL7Segment('AB|campo')).toThrow('Segment ID inválido')
+    })
+
+    it('deve lançar erro para segment ID com 4 chars', () => {
+      expect(() => parseHL7Segment('MSSH|campo')).toThrow('Segment ID inválido')
+    })
+
+    it('deve lançar erro para segmento começando com pipe (sem tipo)', () => {
+      expect(() => parseHL7Segment('|APP|FAC')).toThrow('Segment ID inválido')
+    })
+
+    it('deve lançar erro para número passado como argumento', () => {
       expect(() => parseHL7Segment(123 as unknown as string)).toThrow(
         'Segmento HL7 deve ser uma string válida'
       )
@@ -95,47 +150,37 @@ describe('parseHL7Segment', () => {
 describe('createHL7Segment', () => {
   describe('casos válidos', () => {
     it('deve criar segmento PID com campos', () => {
-      const result = createHL7Segment('PID', ['1', '12345', 'SMITH^JOHN'])
-
-      expect(result).toBe('PID|1|12345|SMITH^JOHN')
+      expect(createHL7Segment('PID', ['1', '12345', 'SMITH^JOHN'])).toBe(
+        'PID|1|12345|SMITH^JOHN'
+      )
     })
 
     it('deve criar segmento MSH com encoding chars', () => {
-      const result = createHL7Segment('MSH', [
-        '^~\\&',
-        'APP',
-        'FAC',
-        '',
-        '',
-        '20231201',
-      ])
-
-      expect(result).toBe('MSH|^~\\&|APP|FAC|||20231201')
+      expect(
+        createHL7Segment('MSH', ['^~\\&', 'APP', 'FAC', '', '', '20231201'])
+      ).toBe('MSH|^~\\&|APP|FAC|||20231201')
     })
 
     it('deve criar segmento com array vazio', () => {
-      const result = createHL7Segment('EVN', [])
-
-      expect(result).toBe('EVN')
+      expect(createHL7Segment('EVN', [])).toBe('EVN')
     })
 
     it('deve preservar campos vazios intermediários', () => {
-      const result = createHL7Segment('PID', ['1', '', 'SMITH^JOHN'])
-
-      expect(result).toBe('PID|1||SMITH^JOHN')
+      expect(createHL7Segment('PID', ['1', '', 'SMITH^JOHN'])).toBe(
+        'PID|1||SMITH^JOHN'
+      )
     })
 
-    it('deve criar segmento com subcomponentes e repetições', () => {
-      const result = createHL7Segment('OBX', [
-        '1',
-        'NM',
-        '8302-2^Body height^LN',
-        '',
-        '175',
-        'cm',
-      ])
+    it('deve aceitar Z-segment (extensão local)', () => {
+      expect(createHL7Segment('ZPD', ['dado1', 'dado2'])).toBe(
+        'ZPD|dado1|dado2'
+      )
+    })
 
-      expect(result).toBe('OBX|1|NM|8302-2^Body height^LN||175|cm')
+    it('deve aceitar tipo com dígito (NK1, OB1)', () => {
+      expect(createHL7Segment('NK1', ['1', 'SMITH^JANE', 'SPO'])).toBe(
+        'NK1|1|SMITH^JANE|SPO'
+      )
     })
   })
 
@@ -146,10 +191,26 @@ describe('createHL7Segment', () => {
       )
     })
 
-    it('deve lançar erro para tipo de segmento null', () => {
+    it('deve lançar erro para tipo null', () => {
       expect(() => createHL7Segment(null as unknown as string, [])).toThrow(
         'Tipo de segmento deve ser uma string válida'
       )
+    })
+
+    it('deve lançar erro para tipo em minúsculas', () => {
+      expect(() => createHL7Segment('pid', [])).toThrow('Segment ID inválido')
+    })
+
+    it('deve lançar erro para tipo com 2 chars', () => {
+      expect(() => createHL7Segment('AB', [])).toThrow('Segment ID inválido')
+    })
+
+    it('deve lançar erro para tipo com 4 chars', () => {
+      expect(() => createHL7Segment('MSSH', [])).toThrow('Segment ID inválido')
+    })
+
+    it('deve lançar erro para tipo com caractere especial', () => {
+      expect(() => createHL7Segment('MS$', [])).toThrow('Segment ID inválido')
     })
 
     it('deve lançar erro para campos null', () => {

--- a/src/__tests__/validation.test.ts
+++ b/src/__tests__/validation.test.ts
@@ -1,5 +1,31 @@
 import { describe, expect, it } from 'vitest'
-import { validateHL7Segment } from '../functions/validation'
+import { normalizeSegment, validateHL7Segment } from '../functions/validation'
+
+describe('normalizeSegment', () => {
+  it('deve remover carriage return do final (terminador HL7)', () => {
+    expect(normalizeSegment('PID|1|12345\r')).toBe('PID|1|12345')
+  })
+
+  it('deve remover espaços nas extremidades', () => {
+    expect(normalizeSegment('  PID|1|12345  ')).toBe('PID|1|12345')
+  })
+
+  it('deve remover \\r e espaços combinados', () => {
+    expect(normalizeSegment('  MSH|^~\\&|APP|FAC  \r')).toBe(
+      'MSH|^~\\&|APP|FAC'
+    )
+  })
+
+  it('deve preservar espaços internos ao segmento', () => {
+    expect(normalizeSegment('PID|1|12345|SMITH JOHN')).toBe(
+      'PID|1|12345|SMITH JOHN'
+    )
+  })
+
+  it('deve retornar string vazia para input vazio', () => {
+    expect(normalizeSegment('')).toBe('')
+  })
+})
 
 describe('validateHL7Segment', () => {
   describe('segmentos válidos', () => {
@@ -19,18 +45,37 @@ describe('validateHL7Segment', () => {
       expect(validateHL7Segment('EVN|A01|20231201120000')).toBe(true)
     })
 
-    it('deve aceitar segmento OBX com campo numérico', () => {
+    it('deve aceitar segmento OBX', () => {
       expect(validateHL7Segment('OBX|1|NM|8302-2^Body height^LN||175|cm')).toBe(
         true
       )
     })
 
-    it('deve aceitar segmento com tipo numérico (ZZ1)', () => {
-      expect(validateHL7Segment('ZZ1|campo1|campo2')).toBe(true)
+    it('deve aceitar Z-segment (extensão local)', () => {
+      expect(validateHL7Segment('ZPD|campo1|campo2')).toBe(true)
+      expect(validateHL7Segment('ZAL|campo1')).toBe(true)
     })
 
-    it('deve aceitar segmento apenas com tipo e sem pipe (MSH)', () => {
+    it('deve aceitar segmento com dígito no tipo (OB1, NK1)', () => {
+      expect(validateHL7Segment('NK1|1|SMITH^JANE')).toBe(true)
+      expect(validateHL7Segment('OB1|campo')).toBe(true)
+    })
+
+    it('deve aceitar segmento apenas com tipo sem pipe', () => {
       expect(validateHL7Segment('MSH')).toBe(true)
+      expect(validateHL7Segment('EVN')).toBe(true)
+    })
+
+    it('deve aceitar segmento com \\r no final (terminador HL7)', () => {
+      expect(validateHL7Segment('PID|1|12345\r')).toBe(true)
+    })
+
+    it('deve aceitar segmento com espaços nas extremidades', () => {
+      expect(validateHL7Segment('  PID|1|12345  ')).toBe(true)
+    })
+
+    it('deve aceitar segmento com \\r e espaços combinados', () => {
+      expect(validateHL7Segment('  MSH|^~\\&|APP  \r')).toBe(true)
     })
   })
 
@@ -47,28 +92,40 @@ describe('validateHL7Segment', () => {
       expect(validateHL7Segment(undefined as unknown as string)).toBe(false)
     })
 
-    it('deve rejeitar segmento com tipo começando por pipe (sem tipo)', () => {
+    it('deve rejeitar segmento sem tipo (começa com pipe)', () => {
       expect(validateHL7Segment('|APP|FACILITY')).toBe(false)
     })
 
-    it('deve rejeitar tipo com 2 caracteres (AB)', () => {
+    it('deve rejeitar tipo com 2 caracteres', () => {
       expect(validateHL7Segment('AB|campo')).toBe(false)
     })
 
-    it('deve rejeitar tipo com 4 caracteres (MSSH)', () => {
+    it('deve rejeitar tipo com 4 caracteres', () => {
       expect(validateHL7Segment('MSSH|campo')).toBe(false)
     })
 
-    it('deve rejeitar tipo em minúsculas (pid)', () => {
+    it('deve rejeitar tipo em minúsculas', () => {
       expect(validateHL7Segment('pid|campo')).toBe(false)
     })
 
-    it('deve rejeitar tipo com caractere especial (MS$)', () => {
+    it('deve rejeitar tipo misto maiúsculas/minúsculas', () => {
+      expect(validateHL7Segment('Pid|campo')).toBe(false)
+    })
+
+    it('deve rejeitar tipo com caractere especial', () => {
       expect(validateHL7Segment('MS$|campo')).toBe(false)
     })
 
     it('deve rejeitar tipo com espaço', () => {
       expect(validateHL7Segment('MS |campo')).toBe(false)
+    })
+
+    it('deve rejeitar string só com \\r', () => {
+      expect(validateHL7Segment('\r')).toBe(false)
+    })
+
+    it('deve rejeitar string só com espaços', () => {
+      expect(validateHL7Segment('   ')).toBe(false)
     })
   })
 })

--- a/src/functions/field-operations.ts
+++ b/src/functions/field-operations.ts
@@ -7,6 +7,12 @@ import { normalizeSegment, validateHL7Segment } from './validation'
  * Retorna string vazia ('') para campos que existem mas estão vazios,
  * e null apenas para índices fora do range ou segmento/índice inválido.
  *
+ * Para segmentos MSH, o índice segue a numeração HL7 v2 §2.14.9:
+ * - índice 0 = segmentType ('MSH')
+ * - índice 1 = MSH-1 (field separator, sempre '|')
+ * - índice 2 = MSH-2 (encoding characters, ex: '^~\&')
+ * - índice N ≥ 3 = MSH-N (campo na posição N)
+ *
  * @param segment - String do segmento HL7 (com ou sem \r no final)
  * @param fieldIndex - Índice do campo (0 = segmentType, 1 = primeiro campo)
  * @returns Valor do campo, '' se vazio, ou null se não existir ou índice inválido
@@ -23,7 +29,27 @@ export function extractFieldValue(
     return null
   }
 
-  const fields = normalizeSegment(segment).split('|')
+  const normalized = normalizeSegment(segment)
+  const firstPipe = normalized.indexOf('|')
+  const segmentType =
+    firstPipe === -1 ? normalized : normalized.slice(0, firstPipe)
+
+  // Tratamento especial para MSH conforme HL7 v2 §2.14.9.
+  // O índice 1 é MSH-1 (o próprio field separator) e o índice 2 é MSH-2
+  // (encoding characters). A partir do índice 2, há um deslocamento de -1
+  // em relação ao split simples por '|', pois MSH-1 não é um campo comum.
+  if (segmentType === 'MSH') {
+    if (fieldIndex === 0) return segmentType
+    const fieldSep = normalized[firstPipe] ?? '|'
+    if (fieldIndex === 1) return fieldSep
+    const fields = normalized.slice(firstPipe + 1).split(fieldSep)
+    // índice 2 → fields[0] (MSH-2, encoding chars), índice N → fields[N-2]
+    const arrayIndex = fieldIndex - 2
+    if (arrayIndex >= fields.length) return null
+    return fields[arrayIndex] ?? null
+  }
+
+  const fields = normalized.split('|')
 
   if (fieldIndex >= fields.length) {
     return null
@@ -56,7 +82,46 @@ export function setFieldValue(
     throw new Error('Índice do campo deve ser um inteiro maior ou igual a 0')
   }
 
-  const fields = normalizeSegment(segment).split('|')
+  const normalized = normalizeSegment(segment)
+  const firstPipe = normalized.indexOf('|')
+  const segmentType =
+    firstPipe === -1 ? normalized : normalized.slice(0, firstPipe)
+
+  // Tratamento especial para MSH conforme HL7 v2 §2.14.9.
+  // O índice 1 (MSH-1, field separator) e o índice 2 (MSH-2, encoding chars)
+  // não podem ser alterados via este método — eles fazem parte da estrutura
+  // do segmento. A partir do índice 2, há um deslocamento de -1 em relação
+  // ao split simples, pois MSH-1 é o próprio separador e não ocupa posição
+  // no array de split.
+  if (segmentType === 'MSH') {
+    const fieldSep = firstPipe !== -1 ? (normalized[firstPipe] ?? '|') : '|'
+    const fields = firstPipe !== -1
+      ? normalized.slice(firstPipe + 1).split(fieldSep)
+      : []
+
+    if (fieldIndex === 0) {
+      // Reescrever apenas o segmentType, mantendo o restante
+      return [value, ...fields].join(fieldSep)
+    }
+
+    // índice 1 = MSH-1 (o separador em si) — não pode ser alterado diretamente
+    // índice 2 = MSH-2 → fields[0]; índice N → fields[N-2]
+    const arrayIndex = fieldIndex === 1 ? -1 : fieldIndex - 2
+
+    if (arrayIndex < 0) {
+      // Tentar mudar o field separator não é suportado; retorna sem alteração
+      return normalized
+    }
+
+    while (fields.length <= arrayIndex) {
+      fields.push('')
+    }
+
+    fields[arrayIndex] = value
+    return [segmentType, fields.join(fieldSep)].join(fieldSep)
+  }
+
+  const fields = normalized.split('|')
 
   while (fields.length <= fieldIndex) {
     fields.push('')

--- a/src/functions/field-operations.ts
+++ b/src/functions/field-operations.ts
@@ -95,9 +95,8 @@ export function setFieldValue(
   // no array de split.
   if (segmentType === 'MSH') {
     const fieldSep = firstPipe !== -1 ? (normalized[firstPipe] ?? '|') : '|'
-    const fields = firstPipe !== -1
-      ? normalized.slice(firstPipe + 1).split(fieldSep)
-      : []
+    const fields =
+      firstPipe !== -1 ? normalized.slice(firstPipe + 1).split(fieldSep) : []
 
     if (fieldIndex === 0) {
       // Reescrever apenas o segmentType, mantendo o restante

--- a/src/functions/field-operations.ts
+++ b/src/functions/field-operations.ts
@@ -1,12 +1,15 @@
-import { validateHL7Segment } from './validation'
+import { normalizeSegment, validateHL7Segment } from './validation'
 
 /**
- * Extrai o valor de um campo específico de um segmento HL7.
- * Retorna string vazia para campos que existem mas estão vazios,
- * e null apenas para índices fora do range do segmento.
- * @param segment - String do segmento HL7
- * @param fieldIndex - Índice do campo (0 = segmentType)
- * @returns Valor do campo, string vazia se vazio, ou null se não existir
+ * Extrai o valor de um campo específico de um segmento HL7 v2.
+ * O terminador \r e espaços nas extremidades são removidos antes da operação.
+ *
+ * Retorna string vazia ('') para campos que existem mas estão vazios,
+ * e null apenas para índices fora do range ou segmento/índice inválido.
+ *
+ * @param segment - String do segmento HL7 (com ou sem \r no final)
+ * @param fieldIndex - Índice do campo (0 = segmentType, 1 = primeiro campo)
+ * @returns Valor do campo, '' se vazio, ou null se não existir ou índice inválido
  */
 export function extractFieldValue(
   segment: string,
@@ -16,7 +19,11 @@ export function extractFieldValue(
     return null
   }
 
-  const fields = segment.split('|')
+  if (!Number.isInteger(fieldIndex) || fieldIndex < 0) {
+    return null
+  }
+
+  const fields = normalizeSegment(segment).split('|')
 
   if (fieldIndex >= fields.length) {
     return null
@@ -26,12 +33,15 @@ export function extractFieldValue(
 }
 
 /**
- * Define o valor de um campo específico em um segmento HL7.
+ * Define o valor de um campo específico em um segmento HL7 v2.
+ * O terminador \r e espaços nas extremidades são removidos antes da operação.
  * Preenche campos intermediários com strings vazias se necessário.
- * @param segment - String do segmento HL7
- * @param fieldIndex - Índice do campo a ser modificado
+ *
+ * @param segment - String do segmento HL7 (com ou sem \r no final)
+ * @param fieldIndex - Índice do campo a ser modificado (0 = segmentType)
  * @param value - Novo valor para o campo
- * @returns String do segmento HL7 atualizado
+ * @returns String do segmento HL7 atualizado (sem \r no final)
+ * @throws Error se o segmento for inválido, o índice for negativo ou não inteiro
  */
 export function setFieldValue(
   segment: string,
@@ -42,11 +52,11 @@ export function setFieldValue(
     throw new Error('Segmento HL7 inválido')
   }
 
-  if (fieldIndex < 0) {
-    throw new Error('Índice do campo deve ser maior ou igual a 0')
+  if (!Number.isInteger(fieldIndex) || fieldIndex < 0) {
+    throw new Error('Índice do campo deve ser um inteiro maior ou igual a 0')
   }
 
-  const fields = segment.split('|')
+  const fields = normalizeSegment(segment).split('|')
 
   while (fields.length <= fieldIndex) {
     fields.push('')

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -6,4 +6,4 @@ export {
   createHL7Segment,
   parseHL7Segment,
 } from './parser'
-export { validateHL7Segment } from './validation'
+export { normalizeSegment, validateHL7Segment } from './validation'

--- a/src/functions/parser.ts
+++ b/src/functions/parser.ts
@@ -1,34 +1,84 @@
 import type { ParsedHL7Segment } from '../types'
+import { normalizeSegment } from './validation'
+
+const SEGMENT_TYPE_REGEX = /^[A-Z0-9]{3}$/
 
 /**
- * Parse um segmento HL7 e retorna um objeto com os campos indexados
- * @param segment - String do segmento HL7
- * @returns Objeto tipado com tipo de segmento e campos field1, field2, etc.
+ * Parseia um segmento HL7 v2 e retorna um objeto com os campos indexados.
+ *
+ * Conformidade HL7 v2.8.2 §2.5:
+ * - O terminador de segmento \r (0x0D) e espaços nas extremidades são removidos
+ *   antes do parse.
+ * - O segment ID deve ter exatamente 3 caracteres alfanuméricos maiúsculos.
+ * - Para o segmento MSH, MSH-1 (field separator) e MSH-2 (encoding characters)
+ *   recebem tratamento especial: MSH-1 é sempre o caractere na posição 3 da
+ *   string e MSH-2 é o conteúdo entre MSH-1 e o próximo MSH-1.
+ *
+ * @param segment - String do segmento HL7 (com ou sem \r no final)
+ * @returns Objeto tipado com segmentType e campos field1, field2, ..., fieldN
+ * @throws Error se o segmento não for uma string válida ou o segment ID for inválido
  */
 export function parseHL7Segment(segment: string): ParsedHL7Segment {
   if (!segment || typeof segment !== 'string') {
     throw new Error('Segmento HL7 deve ser uma string válida')
   }
 
-  const fields = segment.split('|')
-  const result: ParsedHL7Segment = { segmentType: '' }
+  const normalized = normalizeSegment(segment)
+  const firstPipe = normalized.indexOf('|')
+  const segmentType =
+    firstPipe === -1 ? normalized : normalized.slice(0, firstPipe)
 
+  if (!SEGMENT_TYPE_REGEX.test(segmentType)) {
+    throw new Error(
+      `Segment ID inválido: "${segmentType}". Deve ter exatamente 3 caracteres alfanuméricos maiúsculos (A-Z, 0-9)`
+    )
+  }
+
+  const result: ParsedHL7Segment = { segmentType }
+
+  if (firstPipe === -1) {
+    return result
+  }
+
+  // Tratamento especial para MSH conforme HL7 v2 spec §2.14.9:
+  // MSH-1 é o field separator (o próprio | na posição 3).
+  // MSH-2 são os encoding characters (^~\& ou ^~\&# na versão 2.8+).
+  // O split normal por | não funciona porque MSH-1 e MSH-2 têm semântica
+  // diferente dos demais campos.
+  if (segmentType === 'MSH') {
+    const fieldSep = normalized[3] ?? '|'
+    const afterId = normalized.slice(4) // tudo após "MSH|"
+    const mshFields = afterId.split(fieldSep)
+
+    // field1 = MSH-1 (o field separator em si)
+    result.field1 = fieldSep
+    // field2 = MSH-2 (encoding characters, primeiro campo após MSH-1)
+    // e assim por diante a partir de field3
+    mshFields.forEach((field, index) => {
+      result[`field${index + 2}`] = field
+    })
+
+    return result
+  }
+
+  const fields = normalized.slice(firstPipe + 1).split('|')
   fields.forEach((field, index) => {
-    if (index === 0) {
-      result.segmentType = field
-    } else {
-      result[`field${index}`] = field
-    }
+    result[`field${index + 1}`] = field
   })
 
   return result
 }
 
 /**
- * Cria um segmento HL7 a partir do tipo e campos
- * @param segmentType - Tipo do segmento (ex: MSH, PID, PV1)
- * @param fields - Array de campos do segmento
+ * Cria um segmento HL7 v2 a partir do tipo e campos fornecidos.
+ *
+ * O segment ID é validado conforme HL7 v2.8.2 §2.5.2:
+ * deve ter exatamente 3 caracteres alfanuméricos maiúsculos.
+ *
+ * @param segmentType - Tipo do segmento (ex: MSH, PID, PV1, ZPD)
+ * @param fields - Array de strings com os valores dos campos
  * @returns String do segmento HL7 formatado
+ * @throws Error se segmentType for inválido ou fields não for um array
  */
 export function createHL7Segment(
   segmentType: string,
@@ -36,6 +86,12 @@ export function createHL7Segment(
 ): string {
   if (!segmentType || typeof segmentType !== 'string') {
     throw new Error('Tipo de segmento deve ser uma string válida')
+  }
+
+  if (!SEGMENT_TYPE_REGEX.test(segmentType)) {
+    throw new Error(
+      `Segment ID inválido: "${segmentType}". Deve ter exatamente 3 caracteres alfanuméricos maiúsculos (A-Z, 0-9)`
+    )
   }
 
   if (!Array.isArray(fields)) {

--- a/src/functions/validation.ts
+++ b/src/functions/validation.ts
@@ -1,8 +1,19 @@
 const SEGMENT_TYPE_REGEX = /^[A-Z0-9]{3}$/
 
 /**
- * Valida se uma string é um segmento HL7 válido.
- * O tipo do segmento deve ter exatamente 3 caracteres alfanuméricos maiúsculos.
+ * Remove o terminador de segmento HL7 (\r, carriage return 0x0D) e
+ * espaços em branco nas extremidades, conforme HL7 v2 spec cap. 2.
+ */
+export function normalizeSegment(segment: string): string {
+  return segment.trim().replace(/\r$/, '').trimEnd()
+}
+
+/**
+ * Valida se uma string é um segmento HL7 v2 bem formado.
+ * O tipo do segmento deve ter exatamente 3 caracteres alfanuméricos maiúsculos
+ * conforme HL7 v2.8.2 §2.5.2: /^[A-Z0-9]{3}$/.
+ * Segmentos Z (ZPD, ZAL, etc.) são aceitos como extensões locais.
+ * O terminador \r e espaços nas extremidades são ignorados antes da validação.
  * @param segment - String do segmento HL7
  * @returns true se o segmento for válido, false caso contrário
  */
@@ -11,8 +22,10 @@ export function validateHL7Segment(segment: string): boolean {
     return false
   }
 
-  const pipeIndex = segment.indexOf('|')
-  const segmentType = pipeIndex === -1 ? segment : segment.slice(0, pipeIndex)
+  const normalized = normalizeSegment(segment)
+  const pipeIndex = normalized.indexOf('|')
+  const segmentType =
+    pipeIndex === -1 ? normalized : normalized.slice(0, pipeIndex)
 
   return SEGMENT_TYPE_REGEX.test(segmentType)
 }


### PR DESCRIPTION
…cial handling

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HL7 parsing/field operations semantics by trimming segment terminators/whitespace, tightening segment ID validation, and adding special-case `MSH` field handling, which could break existing inputs or downstream expectations.
> 
> **Overview**
> Improves HL7 v2 conformance by introducing `normalizeSegment` (trims trailing `\r` and surrounding whitespace) and applying it across validation and field operations.
> 
> Tightens segment ID rules to exactly 3 uppercase alphanumeric characters (including `Z` segments and digit-containing IDs like `NK1`), updating `parseHL7Segment`/`createHL7Segment` to throw on invalid IDs.
> 
> Adds HL7-spec `MSH` parsing semantics so `parseHL7Segment` returns `field1` as the field separator and `field2` as encoding characters, and expands tests to cover normalization, stricter validation, and the new `MSH` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98efda640dc9f03529b5e526b418204dc7b11026. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->